### PR TITLE
Fixes compilation error (gcc 10.0.1)

### DIFF
--- a/rle.h
+++ b/rle.h
@@ -30,7 +30,7 @@ extern "C" {
  *** 43+3 codec ***
  ******************/
 
-const uint8_t rle_auxtab[8];
+extern const uint8_t rle_auxtab[8];
 
 #define RLE_MIN_SPACE 18
 #define rle_nptr(block) ((uint16_t*)(block))


### PR DESCRIPTION
Hi,
ropebwt2 failed to compile on my system with gcc 10.0.1. Here's the compilation error ([here](https://github.com/lh3/ropebwt2/files/4492423/log.txt) the full log):
```
gcc -g -Wall -O2   rle.o rope.o mrope.o rld0.o crlf.o main.o -o ropebwt2 -lz -lpthread
/usr/bin/ld: rope.o:/home/luca/Software/ropebwt2/rle.h:33: multiple definition of `rle_auxtab'; rle.o:/home/luca/Software/ropebwt2/rle.h:33: first defined here
/usr/bin/ld: main.o:/home/luca/Software/ropebwt2/rle.h:33: multiple definition of `rle_auxtab'; rle.o:/home/luca/Software/ropebwt2/rle.h:33: first defined here
collect2: error: ld returned 1 exit status
make: *** [Makefile:16: ropebwt2] Error 1
```
The problem is that `rle_auxtab` is defined in `rle.h` which is included in multiple files. Making `rle_auxtab` extern seems to solve it.
